### PR TITLE
ISSUE-1 fix (systemd.service): fix service failure when varnish is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to 
 [Semantic Versioning](http://semver.org/).
 
+## 1.0.1
+
+### Added
+
+- make the service more resilient by setting `Restart=always`
+
+### Fixed
+
+- fix issue with service failure after reboot by adding dependency to varnish
+
 ## 1.0.0
 
 ### Added

--- a/templates/etc/systemd/system/varnish_exporter.service.j2
+++ b/templates/etc/systemd/system/varnish_exporter.service.j2
@@ -1,9 +1,12 @@
 [Unit]
 Description=The prometheus varnish exporter
 Documentation=https://github.com/sitewards/ansible-role-varnish-exporter
+After=varnish.service
 
 [Service]
 EnvironmentFile=/etc/default/varnish_exporter
+Restart=always
+RestartSec=60
 
 # Start the service, bound to localhost. It will be exposed by another service, such as NGINX or stunnel.
 ExecStart=/usr/local/bin/prometheus_varnish_exporter \


### PR DESCRIPTION
  If the test scrape fails the unit will not boot, this happens after reboot when this service tries
  to load before varnish is up.

  This commit fixes the issue by making the service load after varnish.
  Additionally the resrvice is now set to `Restart=always` to make it more resilient to failures